### PR TITLE
uuid not returned in the bookmark creation process

### DIFF
--- a/ch2-working-with-actors/Akka/src/main/scala/akkaguide/bookmarkStore.scala
+++ b/ch2-working-with-actors/Akka/src/main/scala/akkaguide/bookmarkStore.scala
@@ -16,8 +16,9 @@ class BookmarkStore(database: Database[Bookmark, UUID]) extends Actor {
       database.find(bookmark) match {
         case Some(found) ⇒ sender ! None
         case None ⇒
-          database.create(UUID.randomUUID, bookmark)
-          sender ! Some(bookmark)
+          val newUUID = UUID.randomUUID
+          database.create(newUUID, bookmark)
+          sender ! Some(newUUID)
       }
     case GetBookmark(uuid) ⇒
       sender ! database.read(uuid)


### PR DESCRIPTION
According to the book the AddBookmark case should return the bookmark uuid. Otherwise I don't see how the client can retrieve the newly added bookmark at a later time
